### PR TITLE
Support image exclusion regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A complete webpack loader for DustJS files.
 ## Overview
 dust-loader-complete is a webpack loader for DustJS files that compiles DustJS template files into their JavaScript template functions. It has a couple of features that distinguish it from the alternatives:
 1. It finds all partials and requires them, which adds them into your webpack bundle.
-2. It finds `<img>` tags and resolves the images specified in the `src` (see options below to disable).
+2. It finds `<img>` tags and resolves the images specified in the `src` (see options below to disable or filter which paths are resolved).
 2. It adds a `templateName` to the compile template function which can be easier to pass around your application if needed.
 
 ### 4.0.1 breaking changes
@@ -56,6 +56,9 @@ Set a root path for your dust templates. This root will be removed from the begi
 
 ### ignoreImages
 Set this to `true` to skip the resolving of image dependencies from your dust templates.
+
+### excludeImageRegex
+Set this to a Regex if you want to exclude some image paths from being resolved. If the contents of the `src` attribute match the Regex, the image tag will not be processed.
 
 ### dustAlias
 If you've set up an alias for `dustjs-linkedin`, you can use this option to instruct the loader to use the same alias.

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ function loader(source) {
     preserveWhitespace: false,
     wrapOutput: false,
     verbose: false,
-    ignoreImages: false
+    ignoreImages: false,
+    excludeImageRegex: undefined
   };
 
   // webpack 4 'this.options' was deprecated in webpack 3 and removed in webpack 4
@@ -151,6 +152,13 @@ function findImages(templateName, source, deps, options) {
     const imageTemplateName = `${templateName}dep${deps.length}`;
 
     log(options, `found image ${src}`);
+
+    // use excludeImageRegex if set to skip images if the path matches the regex
+    const skipImg = options.excludeImageRegex && options.excludeImageRegex.test(src);
+    if (skipImg) {
+      log(options, `skipping image ${src} (matched exclude filter)`);
+      continue;
+    }
 
     // do our own custom registration of a template-like function that will use require to get the actual path
     const srcTemplate = `(function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dust-loader-complete",
-  "version": "4.0.1",
+  "version": "4.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dust-loader-complete",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Webpack loader for DustJS template files",
   "main": "index.js",
   "scripts": {

--- a/test/fixtures/image.dust
+++ b/test/fixtures/image.dust
@@ -2,7 +2,8 @@
 
 {<bodyContent}
 	<img id="first" width="250px" src="./images/dolphin.jpg" style="display:block" />
-	<img src = "./images/dolphin.jpg"/><img src = "./images/dolphin.jpg" id="third"/>
+	<img src="/foo/{skip_this}"/>
+	<img src = "./images/dolphin.jpg"/><img src = "./images/dolphin.jpg" id="dolphin2"/>
 	
 {/bodyContent}
 

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -2,18 +2,26 @@ var path = require('path');
 var dust = require('dustjs');
 var template = require('image');
 
-describe("<img> tags", function () {
-    it('have their "src" attributes converted to the proper relative path', function (done) {
+describe("an <img> tag", function () {
+    it('has its "src" attributes converted to the proper relative path', function (done) {
         dust.render(template, {}, function (err, output) {
             // look for first tag
             expect(output.indexOf('<img id="first" width="250px" src="/assets/images/dolphin.jpg" style="display:block" />')).to.be.greaterThan(-1);
+            done(err);
+        });
+    });
 
-            // look for second tag
+    it('supports multiple <img> tags per line', function (done) {
+        dust.render(template, {}, function (err, output) {
             expect(output.indexOf('<img src = "/assets/images/dolphin.jpg"/>')).to.be.greaterThan(-1);
+            expect(output.indexOf('<img src = "/assets/images/dolphin.jpg" id="dolphin2"/>')).to.be.greaterThan(-1);
+            done(err);
+        });
+    });
 
-            // look for third tag
-            expect(output.indexOf('<img src = "/assets/images/dolphin.jpg" id="third"/>')).to.be.greaterThan(-1);
-
+    it('does not change a tag that matches the excludeImageRegex', function (done) {
+        dust.render(template, {}, function (err, output) {
+            expect(output.indexOf('<img src="/foo/{skip_this}"/>')).to.equal(-1);
             done(err);
         });
     });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,8 @@ module.exports = {
       loader: resolve( __dirname, 'index' ),
       options: {
         root: 'test/fixtures',
-        verbose: true
+        verbose: true,
+        excludeImageRegex: /[{}]/
       }
     }, {
 			test: /\.jpe?g|png|gif|svg$/i,


### PR DESCRIPTION
Added an `excludeImageRegex` option to let the user exclude paths that match the regex from being resolved. This is useful if your template includes `src` attributes that include templated values.