### PR TITLE
adds support for building dust to html files through html-webpack-plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,7 @@ async function loader(source) {
       });
     });
 
+    // Returnd html string for using post html loader
     if (options.preHtmlLoader) return htmlString;
 
     return "module.exports = \"" + htmlString.replace(/\"/g, "\\\"") + "\"";


### PR DESCRIPTION
👋 Hi! I like this loader but I wanted to be able to also render out static html files from my dust templates with partials. I attempted to use dust-loader-complete with html-webpack-plugin but I kept hitting errors. Just seems the plugin doesn't know how to handle the compiled dust scripts. So I added an option flag and a few tweaks to dust-loader-complete get it working. I wanted to maintain normal output for client-side compiled dust templates and found I could set the loader inline as shown in the example.

```
plugins: [
   new HtmlWebpackPlugin({
      filename: 'dust_test2/index.html',
      template: '!!dust-loader-complete?htmlOutput=true!src/views/test.dust',
   }),
],
```

Not sure I handled this the best way but everything is working how I wanted it to. 😁🤞 I figured I would share for feedback and to contribute if its something you guys fits with your package.